### PR TITLE
Replace instances of "master" with "main"

### DIFF
--- a/index.js
+++ b/index.js
@@ -54,10 +54,10 @@ checkIfRepoIsShallow = () => {
 }
 
 gitForcePush = () => {
-    //execSync("git pull heroku master", execOptions)
+    //execSync("git pull heroku main", execOptions)
     //const pull = execSync("git pull --ff-only", execOptions).toString();
     //console.log(pull);
-    const push = execSync("git push --force heroku master", execOptions).toString();
+    const push = execSync("git push --force heroku main", execOptions).toString();
     console.log(push);
 }
 herokuForcePush = ({ app_name }) => {
@@ -65,7 +65,7 @@ herokuForcePush = ({ app_name }) => {
     console.log(push);
 }
 manifestForcePush = () => {
-    const push = execSync('git push --force heroku master', execOptions).toString();
+    const push = execSync('git push --force heroku main', execOptions).toString();
     console.log(push);
 }
 disableCollectStatic = () => {
@@ -110,7 +110,7 @@ deployWithBuildManifest = () => {
         if (heroku.force_push === 'true') {
             manifestForcePush();
         } else {
-            const push = execSync('git push heroku master', execOptions);
+            const push = execSync('git push heroku main', execOptions);
             console.log(push);
         }
 
@@ -169,7 +169,7 @@ deployWithGit = () => {
         if (heroku.force_push === 'true') {
             gitForcePush();
         } else {
-            const push = execSync("git push heroku master", execOptions).toString();
+            const push = execSync("git push heroku main", execOptions).toString();
             console.log(push);
         }
         const migrate = execSync("heroku run python manage.py migrate", execOptions).toString();


### PR DESCRIPTION
For newly created repos, the default branch is "main" on GitHub and not "master". More about this terminology change [here](https://www.techrepublic.com/article/github-to-replace-master-with-main-starting-in-october-what-developers-need-to-know/).

As a result, the current behaviour of this GitHub Action is such that `git push heroku master` fails for new repos because there is no master branch. The error returned is as seen below;

![image](https://user-images.githubusercontent.com/52546943/137839363-f63c6ce1-ecf1-4f63-b43a-95a65979e60e.png)

The changes made were to replace instances of `master` with `main` in the index.js file. So `git push heroku master`, for instance, was replaced with `git push heroku main`. This change resulted in a successful deployment to Heroku.

